### PR TITLE
feat: add calendar date picker

### DIFF
--- a/app/wsr-railway-app/src/components/DatePicker/DatePicker.module.css
+++ b/app/wsr-railway-app/src/components/DatePicker/DatePicker.module.css
@@ -1,61 +1,100 @@
 .datePickerContainer {
+  width: 100%;
+  max-width: 400px;
   display: flex;
-  align-items: center;
-  gap: var(--spacing-md);
+  flex-direction: column;
 }
 
 .label {
+  margin-bottom: var(--spacing-sm);
   font-family: var(--font-header);
   font-size: 1.1rem;
   font-weight: 600;
   color: var(--color-railway-black);
 }
 
-.dateControls {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-sm);
+.calendarWrapper {
   background: white;
   border: 1px solid #CCCCCC;
   border-radius: var(--radius-sm);
-  padding: var(--spacing-xs);
+  padding: var(--spacing-sm);
 }
 
-.dateButton {
+.calendarHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: var(--spacing-sm);
+}
+
+.navButton {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 36px;
-  height: 36px;
+  width: 32px;
+  height: 32px;
   background: var(--color-wsr-burgundy);
   color: white;
   border: none;
   border-radius: var(--radius-sm);
-  font-size: 1.2rem;
   cursor: pointer;
-  transition: all var(--transition-fast);
 }
 
-.dateButton:hover:not(:disabled) {
+.navButton:hover {
   background: var(--color-wsr-dark-burgundy);
 }
 
-.dateButton:disabled {
-  opacity: 0.4;
-  cursor: not-allowed;
+.monthLabel {
+  font-family: var(--font-header);
+  font-size: 1rem;
+  font-weight: 600;
 }
 
-.dateDisplay {
-  padding: var(--spacing-sm) var(--spacing-lg);
-  font-family: var(--font-body);
-  font-size: 1rem;
-  font-weight: 500;
-  color: var(--color-railway-black);
-  min-width: 180px;
+.calendar {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.calendar th {
+  font-weight: 600;
   text-align: center;
+  padding: var(--spacing-xs);
+  font-size: 0.8rem;
+}
+
+.calendar td {
+  text-align: center;
+  padding: var(--spacing-xs);
+}
+
+.dayButton {
+  width: 100%;
+  height: 40px;
+  border: none;
+  border-radius: var(--radius-sm);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2px;
+  cursor: pointer;
+  color: var(--color-railway-black);
+}
+
+.dayButton.selected {
+  outline: 2px solid var(--color-wsr-burgundy);
+}
+
+.dayNumber {
+  font-size: 0.8rem;
+}
+
+.trainCount {
+  font-size: 0.7rem;
 }
 
 .todayButton {
+  margin-top: var(--spacing-sm);
   padding: var(--spacing-sm) var(--spacing-md);
   background: var(--color-wsr-burgundy);
   color: white;
@@ -73,3 +112,4 @@
 .todayButton:hover {
   background: var(--color-wsr-dark-burgundy);
 }
+

--- a/app/wsr-railway-app/src/components/DatePicker/DatePicker.module.css
+++ b/app/wsr-railway-app/src/components/DatePicker/DatePicker.module.css
@@ -13,6 +13,26 @@
   color: var(--color-railway-black);
 }
 
+.dateControls {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-sm);
+  margin-bottom: var(--spacing-sm);
+}
+
+.selectedDateButton {
+  padding: var(--spacing-xs) var(--spacing-md);
+  border: none;
+  border-radius: var(--radius-sm);
+  font-family: var(--font-body);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  color: var(--color-railway-black);
+}
+
 .calendarWrapper {
   background: white;
   border: 1px solid #CCCCCC;

--- a/app/wsr-railway-app/src/components/DatePicker/DatePicker.tsx
+++ b/app/wsr-railway-app/src/components/DatePicker/DatePicker.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import styles from './DatePicker.module.css';
 
 interface DatePickerProps {
@@ -12,64 +12,165 @@ export const DatePicker: React.FC<DatePickerProps> = ({
   onDateChange,
   label = 'Travel Date'
 }) => {
-  const handlePreviousDay = () => {
-    const newDate = new Date(selectedDate);
-    newDate.setDate(newDate.getDate() - 1);
-    onDateChange(newDate);
+  const [currentMonth, setCurrentMonth] = useState(
+    new Date(selectedDate.getFullYear(), selectedDate.getMonth(), 1)
+  );
+  const [trainCounts, setTrainCounts] = useState<Record<string, number>>({});
+
+  useEffect(() => {
+    const daysInMonth = new Date(
+      currentMonth.getFullYear(),
+      currentMonth.getMonth() + 1,
+      0
+    ).getDate();
+    const counts: Record<string, number> = {};
+    for (let day = 1; day <= daysInMonth; day++) {
+      const key = `${currentMonth.getFullYear()}-${currentMonth.getMonth()}-${day}`;
+      counts[key] = Math.floor(Math.random() * 11);
+    }
+    setTrainCounts(counts);
+  }, [currentMonth]);
+
+  useEffect(() => {
+    setCurrentMonth(
+      new Date(selectedDate.getFullYear(), selectedDate.getMonth(), 1)
+    );
+  }, [selectedDate]);
+
+  const handlePrevMonth = () => {
+    setCurrentMonth(
+      new Date(currentMonth.getFullYear(), currentMonth.getMonth() - 1, 1)
+    );
   };
 
-  const handleNextDay = () => {
-    const newDate = new Date(selectedDate);
-    newDate.setDate(newDate.getDate() + 1);
-    onDateChange(newDate);
+  const handleNextMonth = () => {
+    setCurrentMonth(
+      new Date(currentMonth.getFullYear(), currentMonth.getMonth() + 1, 1)
+    );
   };
 
   const handleToday = () => {
     onDateChange(new Date());
   };
 
-  const formatDate = (date: Date) => {
-    const options: Intl.DateTimeFormatOptions = { 
-      weekday: 'short', 
-      year: 'numeric', 
-      month: 'short', 
-      day: 'numeric' 
-    };
-    return date.toLocaleDateString('en-GB', options);
+  const handleDateClick = (date: Date) => {
+    onDateChange(date);
   };
 
-  const isToday = (date: Date) => {
-    const today = new Date();
-    return date.toDateString() === today.toDateString();
+  const formatMonthYear = (date: Date) =>
+    date.toLocaleDateString('en-GB', { month: 'long', year: 'numeric' });
+
+  const startDay = (() => {
+    const day = new Date(
+      currentMonth.getFullYear(),
+      currentMonth.getMonth(),
+      1
+    ).getDay();
+    return (day + 6) % 7; // Monday start
+  })();
+
+  const daysInMonth = new Date(
+    currentMonth.getFullYear(),
+    currentMonth.getMonth() + 1,
+    0
+  ).getDate();
+
+  const weeks: (Date | null)[][] = [];
+  let dayCounter = 1 - startDay;
+
+  while (dayCounter <= daysInMonth) {
+    const week: (Date | null)[] = [];
+    for (let i = 0; i < 7; i++) {
+      if (dayCounter > 0 && dayCounter <= daysInMonth) {
+        week.push(
+          new Date(currentMonth.getFullYear(), currentMonth.getMonth(), dayCounter)
+        );
+      } else {
+        week.push(null);
+      }
+      dayCounter++;
+    }
+    weeks.push(week);
+  }
+
+  const dateKey = (date: Date) =>
+    `${date.getFullYear()}-${date.getMonth()}-${date.getDate()}`;
+
+  const getColor = (count: number) => {
+    const hue = (count / 10) * 120;
+    return `hsl(${hue}, 70%, 85%)`;
   };
 
   return (
     <div className={styles.datePickerContainer}>
       <span className={styles.label}>{label}:</span>
-      <div className={styles.dateControls}>
-        <button
-          className={styles.dateButton}
-          onClick={handlePreviousDay}
-          aria-label="Previous day"
-        >
-          ←
-        </button>
-        <div className={styles.dateDisplay}>
-          {formatDate(selectedDate)}
+      <div className={styles.calendarWrapper}>
+        <div className={styles.calendarHeader}>
+          <button
+            className={styles.navButton}
+            onClick={handlePrevMonth}
+            aria-label="Previous month"
+          >
+            ←
+          </button>
+          <div className={styles.monthLabel}>
+            {formatMonthYear(currentMonth)}
+          </div>
+          <button
+            className={styles.navButton}
+            onClick={handleNextMonth}
+            aria-label="Next month"
+          >
+            →
+          </button>
         </div>
-        <button
-          className={styles.dateButton}
-          onClick={handleNextDay}
-          aria-label="Next day"
-        >
-          →
-        </button>
+        <table className={styles.calendar}>
+          <thead>
+            <tr>
+              {['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'].map(day => (
+                <th key={day}>{day}</th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {weeks.map((week, i) => (
+              <tr key={i}>
+                {week.map((date, j) => {
+                  if (!date) {
+                    return <td key={j}></td>;
+                  }
+                  const key = dateKey(date);
+                  const count = trainCounts[key] ?? 0;
+                  const isSelected =
+                    date.toDateString() === selectedDate.toDateString();
+                  return (
+                    <td key={j}>
+                      <button
+                        className={`${styles.dayButton} ${
+                          isSelected ? styles.selected : ''
+                        }`}
+                        style={{ backgroundColor: getColor(count) }}
+                        onClick={() => handleDateClick(date)}
+                      >
+                        <span className={styles.dayNumber}>
+                          {date.getDate()}
+                        </span>
+                        <span className={styles.trainCount}>{count}</span>
+                      </button>
+                    </td>
+                  );
+                })}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        {!(selectedDate.toDateString() === new Date().toDateString()) && (
+          <button className={styles.todayButton} onClick={handleToday}>
+            Today
+          </button>
+        )}
       </div>
-      {!isToday(selectedDate) && (
-        <button className={styles.todayButton} onClick={handleToday}>
-          Today
-        </button>
-      )}
     </div>
   );
 };
+

--- a/app/wsr-railway-app/src/components/DatePicker/DatePicker.tsx
+++ b/app/wsr-railway-app/src/components/DatePicker/DatePicker.tsx
@@ -16,6 +16,7 @@ export const DatePicker: React.FC<DatePickerProps> = ({
     new Date(selectedDate.getFullYear(), selectedDate.getMonth(), 1)
   );
   const [trainCounts, setTrainCounts] = useState<Record<string, number>>({});
+  const [showCalendar, setShowCalendar] = useState(false);
 
   useEffect(() => {
     const daysInMonth = new Date(
@@ -49,12 +50,38 @@ export const DatePicker: React.FC<DatePickerProps> = ({
     );
   };
 
+  const handlePrevDay = () => {
+    onDateChange(
+      new Date(
+        selectedDate.getFullYear(),
+        selectedDate.getMonth(),
+        selectedDate.getDate() - 1
+      )
+    );
+  };
+
+  const handleNextDay = () => {
+    onDateChange(
+      new Date(
+        selectedDate.getFullYear(),
+        selectedDate.getMonth(),
+        selectedDate.getDate() + 1
+      )
+    );
+  };
+
   const handleToday = () => {
     onDateChange(new Date());
+    setShowCalendar(false);
   };
 
   const handleDateClick = (date: Date) => {
     onDateChange(date);
+    setShowCalendar(false);
+  };
+
+  const toggleCalendar = () => {
+    setShowCalendar(prev => !prev);
   };
 
   const formatMonthYear = (date: Date) =>
@@ -101,75 +128,104 @@ export const DatePicker: React.FC<DatePickerProps> = ({
     return `hsl(${hue}, 70%, 85%)`;
   };
 
+  const selectedKey = dateKey(selectedDate);
+  const selectedCount = trainCounts[selectedKey] ?? 0;
+
   return (
     <div className={styles.datePickerContainer}>
       <span className={styles.label}>{label}:</span>
-      <div className={styles.calendarWrapper}>
-        <div className={styles.calendarHeader}>
-          <button
-            className={styles.navButton}
-            onClick={handlePrevMonth}
-            aria-label="Previous month"
-          >
-            ←
-          </button>
-          <div className={styles.monthLabel}>
-            {formatMonthYear(currentMonth)}
-          </div>
-          <button
-            className={styles.navButton}
-            onClick={handleNextMonth}
-            aria-label="Next month"
-          >
-            →
-          </button>
-        </div>
-        <table className={styles.calendar}>
-          <thead>
-            <tr>
-              {['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'].map(day => (
-                <th key={day}>{day}</th>
-              ))}
-            </tr>
-          </thead>
-          <tbody>
-            {weeks.map((week, i) => (
-              <tr key={i}>
-                {week.map((date, j) => {
-                  if (!date) {
-                    return <td key={j}></td>;
-                  }
-                  const key = dateKey(date);
-                  const count = trainCounts[key] ?? 0;
-                  const isSelected =
-                    date.toDateString() === selectedDate.toDateString();
-                  return (
-                    <td key={j}>
-                      <button
-                        className={`${styles.dayButton} ${
-                          isSelected ? styles.selected : ''
-                        }`}
-                        style={{ backgroundColor: getColor(count) }}
-                        onClick={() => handleDateClick(date)}
-                      >
-                        <span className={styles.dayNumber}>
-                          {date.getDate()}
-                        </span>
-                        <span className={styles.trainCount}>{count}</span>
-                      </button>
-                    </td>
-                  );
-                })}
-              </tr>
-            ))}
-          </tbody>
-        </table>
-        {!(selectedDate.toDateString() === new Date().toDateString()) && (
-          <button className={styles.todayButton} onClick={handleToday}>
-            Today
-          </button>
-        )}
+      <div className={styles.dateControls}>
+        <button
+          className={styles.navButton}
+          onClick={handlePrevDay}
+          aria-label="Previous day"
+        >
+          ←
+        </button>
+        <button
+          className={styles.selectedDateButton}
+          style={{ backgroundColor: getColor(selectedCount) }}
+          onClick={toggleCalendar}
+        >
+          {selectedDate.toLocaleDateString('en-GB')}
+          <span className={styles.trainCount}>{selectedCount}</span>
+        </button>
+        <button
+          className={styles.navButton}
+          onClick={handleNextDay}
+          aria-label="Next day"
+        >
+          →
+        </button>
       </div>
+      {showCalendar && (
+        <div className={styles.calendarWrapper}>
+          <div className={styles.calendarHeader}>
+            <button
+              className={styles.navButton}
+              onClick={handlePrevMonth}
+              aria-label="Previous month"
+            >
+              ←
+            </button>
+            <div className={styles.monthLabel}>
+              {formatMonthYear(currentMonth)}
+            </div>
+            <button
+              className={styles.navButton}
+              onClick={handleNextMonth}
+              aria-label="Next month"
+            >
+              →
+            </button>
+          </div>
+          <table className={styles.calendar}>
+            <thead>
+              <tr>
+                {['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'].map(day => (
+                  <th key={day}>{day}</th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {weeks.map((week, i) => (
+                <tr key={i}>
+                  {week.map((date, j) => {
+                    if (!date) {
+                      return <td key={j}></td>;
+                    }
+                    const key = dateKey(date);
+                    const count = trainCounts[key] ?? 0;
+                    const isSelected =
+                      date.toDateString() === selectedDate.toDateString();
+                    return (
+                      <td key={j}>
+                        <button
+                          className={`${styles.dayButton} ${
+                            isSelected ? styles.selected : ''
+                          }`}
+                          style={{ backgroundColor: getColor(count) }}
+                          onClick={() => handleDateClick(date)}
+                        >
+                          <span className={styles.dayNumber}>
+                            {date.getDate()}
+                          </span>
+                          <span className={styles.trainCount}>{count}</span>
+                        </button>
+                      </td>
+                    );
+                  })}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          {!(selectedDate.toDateString() === new Date().toDateString()) && (
+            <button className={styles.todayButton} onClick={handleToday}>
+              Today
+            </button>
+          )}
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add interactive calendar widget with month navigation
- color calendar days by randomly generated train counts
- highlight selected travel date and provide quick reset to today

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b0dd0765ac83338c7417319f85ea1a